### PR TITLE
Introduce a hysteresis for outdoor condition determination.

### DIFF
--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/display/AmbientLuxObserver.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/display/AmbientLuxObserver.java
@@ -38,6 +38,7 @@ public class AmbientLuxObserver {
     private final SensorManager mSensorManager;
 
     private final float mThresholdLux;
+    private final float mHysteresisLux;
     private final int mThresholdDuration;
 
     private boolean mLightSensorEnabled = false;
@@ -61,9 +62,10 @@ public class AmbientLuxObserver {
     }
 
     public AmbientLuxObserver(Context context, Looper looper,
-            float thresholdLux, int thresholdDuration) {
+            float thresholdLux, float hysteresisLux, int thresholdDuration) {
         mLuxHandler = new AmbientLuxHandler(looper);
         mThresholdLux = thresholdLux;
+        mHysteresisLux = hysteresisLux;
         mThresholdDuration = thresholdDuration;
         mRingBuffer = new TimedMovingAverageRingBuffer(thresholdDuration);
 
@@ -103,7 +105,9 @@ public class AmbientLuxObserver {
                                        " mAmbientLux=" + mAmbientLux);
                         }
 
-                        direction = mAmbientLux >= mThresholdLux ? HIGH : LOW;
+                        final float threshold = mState == HIGH
+                                ? mThresholdLux - mHysteresisLux : mThresholdLux;
+                        direction = mAmbientLux >= threshold ? HIGH : LOW;
                         if (mState != direction) {
                             mState = direction;
                             if (mCallback != null) {

--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/display/OutdoorModeController.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/display/OutdoorModeController.java
@@ -40,6 +40,7 @@ public class OutdoorModeController extends LiveDisplayFeature {
 
     // default values
     private final int mDefaultOutdoorLux;
+    private final int mOutdoorLuxHysteresis;
     private final boolean mDefaultAutoOutdoorMode;
     private final boolean mSelfManaged;
 
@@ -59,6 +60,8 @@ public class OutdoorModeController extends LiveDisplayFeature {
 
         mDefaultOutdoorLux = mContext.getResources().getInteger(
                 org.cyanogenmod.platform.internal.R.integer.config_outdoorAmbientLux);
+        mOutdoorLuxHysteresis = mContext.getResources().getInteger(
+                org.cyanogenmod.platform.internal.R.integer.config_outdoorAmbientLuxHysteresis);
         mDefaultAutoOutdoorMode = mContext.getResources().getBoolean(
                 org.cyanogenmod.platform.internal.R.bool.config_defaultAutoOutdoorMode);
     }
@@ -71,7 +74,7 @@ public class OutdoorModeController extends LiveDisplayFeature {
 
         if (!mSelfManaged) {
             mLuxObserver = new AmbientLuxObserver(mContext, mHandler.getLooper(),
-                    mDefaultOutdoorLux, SENSOR_WINDOW_MS);
+                    mDefaultOutdoorLux, mOutdoorLuxHysteresis, SENSOR_WINDOW_MS);
         }
 
         registerSettings(
@@ -128,6 +131,7 @@ public class OutdoorModeController extends LiveDisplayFeature {
         pw.println("  mSelfManaged=" + mSelfManaged);
         if (!mSelfManaged) {
             pw.println("  mDefaultOutdoorLux=" + mDefaultOutdoorLux);
+            pw.println("  mOutdoorLuxHysteresis=" + mOutdoorLuxHysteresis);
             pw.println();
             pw.println("  OutdoorModeController State:");
             pw.println("    mAutoOutdoorMode=" + isAutomaticOutdoorModeEnabled());

--- a/cm/res/res/values/config.xml
+++ b/cm/res/res/values/config.xml
@@ -55,6 +55,7 @@
     <integer name="config_dayColorTemperature">6500</integer>
     <integer name="config_nightColorTemperature">4800</integer>
     <integer name="config_outdoorAmbientLux">12000</integer>
+    <integer name="config_outdoorAmbientLuxHysteresis">1500</integer>
     <integer name="config_defaultLiveDisplayMode">2</integer>
 
     <!-- These values should map to the true min and max

--- a/cm/res/res/values/symbols.xml
+++ b/cm/res/res/values/symbols.xml
@@ -72,6 +72,7 @@
     <java-symbol type="integer" name="config_dayColorTemperature" />
     <java-symbol type="integer" name="config_nightColorTemperature" />
     <java-symbol type="integer" name="config_outdoorAmbientLux" />
+    <java-symbol type="integer" name="config_outdoorAmbientLuxHysteresis" />
     <java-symbol type="integer" name="config_defaultLiveDisplayMode" />
     <java-symbol type="integer" name="config_minColorTemperature" />
     <java-symbol type="integer" name="config_maxColorTemperature" />


### PR DESCRIPTION
Avoids flicker when brightness is around the threshold.

Change-Id: I8658725450496b89123abb26b6ef8ce333c709e5