### PR TITLE
cmsdk: allow MANAGE_AUDIO_SESSIONS to be whitelisted

### DIFF
--- a/cm/res/AndroidManifest.xml
+++ b/cm/res/AndroidManifest.xml
@@ -226,7 +226,8 @@
     <permission android:name="cyanogenmod.permission.MANAGE_AUDIO_SESSIONS"
                 android:label="@string/permlab_manage_audio_sessions"
                 android:description="@string/permdesc_manage_audio_sessions"
-                android:protectionLevel="signature|privileged"/>
+                android:protectionLevel="signature|privileged"
+                androidprv:allowViaWhitelist="true" />
 
     <!-- Allows an application to access the weather service.
         <p>Although the protection is normal, this permission should be required ONLY by those apps


### PR DESCRIPTION
So the implementing service doesn't have to be signed with platform
keys.

Change-Id: I635d79173bf1771b58e1cb2dd333cee091610a48
Signed-off-by: Roman Birg <roman@cyngn.com>